### PR TITLE
Enable multiple file uploads and remove zip file processing

### DIFF
--- a/hw.py
+++ b/hw.py
@@ -162,9 +162,7 @@ if (
                                 (student_name, score, feedback)
                             )
                         except Exception as e:
-                            st.error(
-                                f"Error processing file {file_info.filename}: {str(e)}"
-                            )
+                            st.error(f"Error processing file {file_info.filename}: {e}")
 
         st.session_state.processed_files.add(uploaded_file.name)
 

--- a/hw.py
+++ b/hw.py
@@ -119,6 +119,7 @@ uploaded_files = st.file_uploader(
 if type(uploaded_files) is not list:
     uploaded_files = [uploaded_files]
 
+MAX_RETRIES = 4
 for uploaded_file in uploaded_files:
     if uploaded_file and uploaded_file.name not in st.session_state.processed_files:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -139,7 +140,7 @@ for uploaded_file in uploaded_files:
                         break
                     except Exception as e:
                         retries += 1
-                        if retries > 3:
+                        if retries > MAX_RETRIES:
                             st.error(f"Failed to process {uploaded_file.name}: {e}")
                             break
 

--- a/hw.py
+++ b/hw.py
@@ -79,12 +79,14 @@ def create_excel_grade(students_data):
 
     ws["A1"] = "File Name"
     ws["B1"] = "Score"
+    ws["C1"] = "Feedback"
 
-    for row, (name, score) in enumerate(students_data, start=2):
+    for row, (name, score, feedback) in enumerate(students_data, start=2):
         # Normalize the Korean name to composed form
         normalized_name = unicodedata.normalize("NFC", name)
         ws[f"A{row}"] = normalized_name
         ws[f"B{row}"] = score
+        ws[f"C{row}"] = feedback
 
     return wb
 
@@ -114,7 +116,7 @@ def process_pdf_file(file_path):
         score_match = re.search(r"Score: (\d+)", full_response)
         score = score_match.group(1) if score_match else "N/A"
 
-        return student_name, score
+        return student_name, score, full_response
 
 
 uploaded_file = st.file_uploader(
@@ -132,8 +134,8 @@ if (
             f.write(uploaded_file.getvalue())
 
         if uploaded_file.name.endswith(".pdf"):
-            student_name, score = process_pdf_file(file_path)
-            st.session_state.students_data.append((student_name, score))
+            student_name, score, feedback = process_pdf_file(file_path)
+            st.session_state.students_data.append((student_name, score, feedback))
 
         elif uploaded_file.name.endswith(".zip"):
             with zipfile.ZipFile(file_path, "r") as z:
@@ -151,10 +153,14 @@ if (
                                 extracted_path, "wb"
                             ) as target:
                                 target.write(source.read())
-                            student_name, score = process_pdf_file(extracted_path)
+                            student_name, score, feedback = process_pdf_file(
+                                extracted_path
+                            )
                             # Use the original filename for display and grading
                             student_name = os.path.splitext(original_filename)[0]
-                            st.session_state.students_data.append((student_name, score))
+                            st.session_state.students_data.append(
+                                (student_name, score, feedback)
+                            )
                         except Exception as e:
                             st.error(
                                 f"Error processing file {file_info.filename}: {str(e)}"

--- a/hw.py
+++ b/hw.py
@@ -128,10 +128,21 @@ for uploaded_file in uploaded_files:
                 f.write(uploaded_file.getvalue())
 
             if uploaded_file.name.endswith(".pdf"):
-                student_name, score, feedback = process_pdf_file(file_path)
-                st.session_state.students_data.append((student_name, score, feedback))
+                retries = 0
+                while True:
+                    try:
+                        student_name, score, feedback = process_pdf_file(file_path)
+                        st.session_state.students_data.append(
+                            (student_name, score, feedback)
+                        )
+                        st.session_state.processed_files.add(uploaded_file.name)
+                        break
+                    except Exception as e:
+                        retries += 1
+                        if retries > 3:
+                            st.error(f"Failed to process {uploaded_file.name}: {e}")
+                            break
 
-            st.session_state.processed_files.add(uploaded_file.name)
 
 if st.session_state.students_data:
     wb = create_excel_grade(st.session_state.students_data)

--- a/hw.py
+++ b/hw.py
@@ -189,7 +189,7 @@ if st.session_state.processed_files:
 
 if st.session_state.students_data:
     st.write("Current Grades:")
-    for name, score in st.session_state.students_data:
+    for name, score, _ in st.session_state.students_data:
         st.text(f"{name}: {score}")
 
 # Add a button to clear the session state


### PR DESCRIPTION
- Zip file processing seems to be unstable (unpredictable&random failures), but multiple file upload works nicely.
- Retry at most 4 times in case of API failure.
- Record feedbacks in the excel report.